### PR TITLE
Allocate all memory up front

### DIFF
--- a/draw.c
+++ b/draw.c
@@ -35,21 +35,15 @@ void draw_frame(int width, int height)
 
 void draw_snake(const t_snake *snake)
 {
-    if (snake->next)
-    {
-        printf("\033[%d;%dH\033[42m \033[0m", snake->next->pos.row, snake->next->pos.col);
-    }
-
-    printf("\033[%d;%dH\033[102;30m \033[0m", snake->pos.row, snake->pos.col);
+    printf("\033[%d;%dH\033[42m \033[0m", snake[1].pos.row, snake[1].pos.col);
+    printf("\033[%d;%dH\033[102;30m \033[0m", snake[0].pos.row, snake[0].pos.col);
 }
 
-void clear_snake(const t_snake *snake)
+void clear_snake(const t_snake *snake, int snake_length)
 {
     // Only necessary to clear tail
-    while (snake->next != NULL)
-        snake = snake->next;
-
-    printf("\033[%d;%dH ", snake->pos.row, snake->pos.col);
+    const t_snake *s = &snake[snake_length-1];
+    printf("\033[%d;%dH ", s->pos.row, s->pos.col);
 }
 
 void draw_candy(t_pos *candy)

--- a/draw.h
+++ b/draw.h
@@ -9,7 +9,7 @@ void draw_frame(int width, int height);
 
 void draw_snake(const t_snake *snake);
 
-void clear_snake(const t_snake *snake);
+void clear_snake(const t_snake *snake, int snake_length);
 
 void draw_candy(t_pos *candy);
 

--- a/game.c
+++ b/game.c
@@ -118,15 +118,7 @@ static void move_snake(t_snake *snake, int snake_length)
 
 static void grow() {
     // Ensure we have capacity to grow
-    if(game->snake_capacity <= game->snake_length)
-    {
-        unsigned int new_capacity = game->snake_capacity * 2;
-        t_snake *new_snake = (t_snake *)realloc(game->snake, sizeof(t_snake) * new_capacity);
-        assert(new_snake);
-
-        game->snake_capacity = new_capacity;
-        game->snake = new_snake;
-    }
+    assert(game->snake_length < game->snake_capacity);
 
     t_snake *tail = &game->snake[game->snake_length];
 

--- a/game.c
+++ b/game.c
@@ -42,8 +42,6 @@ static void initialize()
     game->snake[1].dir = LEFT;
 
     // Bucket of candy
-    game->candy = (t_pos*)malloc(sizeof(t_pos) * N_CANDY);
-    assert(game->candy);
     for (int i = 0; i < N_CANDY; i++)
     {
         game->candy[i].row = 0;

--- a/game.c
+++ b/game.c
@@ -25,10 +25,7 @@ static int highscore;
 
 static void initialize()
 {
-    game->snake = (t_snake*)calloc(2, sizeof(t_snake));
-    assert(game->snake);
     game->snake_length = 2;
-    game->snake_capacity = 2;
 
     // Create snake at the center
     t_pos center;
@@ -54,7 +51,6 @@ static void initialize()
 
 static void destroy()
 {
-    free(game->snake);
 }
 
 static void handle_input()
@@ -309,8 +305,15 @@ t_game* new_game(unsigned short rows, unsigned short cols)
 
     highscore = 0;
 
-    game = (t_game*)malloc(sizeof(t_game));
-    assert(game);
+    int max_snake_length = (rows-2) * (cols-2);
+    unsigned char *game_memory =
+        (unsigned char *)malloc(sizeof(t_game) +
+        max_snake_length * sizeof(t_snake));
+    assert(game_memory);
+
+    game = (t_game*)game_memory;
+    game->snake = (t_snake *)(game_memory + sizeof(t_game));
+    game->snake_capacity = max_snake_length;
     game->w_width = cols;
     game->w_height = rows - 1;
     game->start = &start;

--- a/game.c
+++ b/game.c
@@ -55,7 +55,6 @@ static void initialize()
 static void destroy()
 {
     free(game->snake);
-    free(game->candy);
 }
 
 static void handle_input()

--- a/game.c
+++ b/game.c
@@ -49,10 +49,6 @@ static void initialize()
     game->is_paused = 0;
 }
 
-static void destroy()
-{
-}
-
 static void handle_input()
 {
     e_input input = read_input();
@@ -272,8 +268,6 @@ static void start()
                 draw_statusbar(game->w_height + 1, game->speed,
                                game->points, highscore, game->is_paused);
             }
-
-            destroy();
 
             t_pos center = {.col = game->w_width / 2, .row = game->w_height / 2};
             draw_game_over(&center);

--- a/game.c
+++ b/game.c
@@ -308,7 +308,7 @@ t_game* new_game(unsigned short rows, unsigned short cols)
         max_snake_length * sizeof(t_snake);
     unsigned char *game_memory = (unsigned char *)malloc(game_memory_size);
     assert(game_memory);
-    debug("Allocated %u kB of memory for the game.\n", game_memory_size);
+    debug("Allocated %u kB of memory for the game.\n", game_memory_size >> 10);
 
     game = (t_game*)game_memory;
     game->snake = (t_snake *)(game_memory + sizeof(t_game));

--- a/game.c
+++ b/game.c
@@ -25,7 +25,7 @@ static int highscore;
 
 static void initialize()
 {
-    game->snake = (t_snake*)calloc(sizeof(t_snake), 2);
+    game->snake = (t_snake*)calloc(2, sizeof(t_snake));
     assert(game->snake);
     game->snake_length = 2;
     game->snake_capacity = 2;

--- a/game.c
+++ b/game.c
@@ -291,11 +291,24 @@ t_game* new_game(unsigned short rows, unsigned short cols)
 
     highscore = 0;
 
+    /*
+     * In order to get only a single memory allocation, we
+     * compute the amount of memory needed here, and do a
+     * single call to malloc. The memory needed is the size
+     * of the t_game struct, as well as memory for all the
+     * snake body positions.
+     * Reducing the calls to (m/c/re)alloc reduces the number
+     * of syscalls we produce, the number of possible error
+     * locations in our code, simplifies freeing and cleaning
+     * up, as well as packing all of our data tightly in memory,
+     * which is good for cache locality and the memory bus.
+     */
     int max_snake_length = (rows-2) * (cols-2);
-    unsigned char *game_memory =
-        (unsigned char *)malloc(sizeof(t_game) +
-        max_snake_length * sizeof(t_snake));
+    unsigned int game_memory_size = sizeof(t_game) +
+        max_snake_length * sizeof(t_snake);
+    unsigned char *game_memory = (unsigned char *)malloc(game_memory_size);
     assert(game_memory);
+    debug("Allocated %u kB of memory for the game.\n", game_memory_size);
 
     game = (t_game*)game_memory;
     game->snake = (t_snake *)(game_memory + sizeof(t_game));

--- a/game.h
+++ b/game.h
@@ -17,13 +17,14 @@ typedef struct {
 typedef struct t_snake {
     t_pos pos;
     e_dir dir;
-    struct t_snake *next;
 } t_snake;
 
 typedef unsigned char t_bool;
 
 typedef struct {
     t_snake *snake;
+    unsigned int snake_length;
+    unsigned int snake_capacity;
     t_pos *candy;
     unsigned short w_width;
     unsigned short w_height;

--- a/game.h
+++ b/game.h
@@ -25,7 +25,7 @@ typedef struct {
     t_snake *snake;
     unsigned int snake_length;
     unsigned int snake_capacity;
-    t_pos *candy;
+    t_pos candy[N_CANDY];
     unsigned short w_width;
     unsigned short w_height;
     t_bool is_running;


### PR DESCRIPTION
Commits move gradually towards fewer memory allocations. The final one uses a slight hack to allocate both the `t_game` struct and the full capacity `t_snake` array in one malloc, which is not very pretty, but results in a single allocation, and ensures tight packing in memory for all game data.
I believe this closes #13 